### PR TITLE
feat(metadata-service): implement fake metadata backend in go (DSP-1579)

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -369,6 +369,13 @@ def go_dependencies():
         version = "v1.7.0",
     )
     go_repository(
+        name = "com_github_felixge_httpsnoop",
+        importpath = "github.com/felixge/httpsnoop",
+        sum = "h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=",
+        version = "v1.0.1",
+    )
+
+    go_repository(
         name = "com_github_franela_goblin",
         importpath = "github.com/franela/goblin",
         sum = "h1:gb2Z18BhTPJPpLQWj4T+rfKHYCHxRHCtRxhKKjRidVw=",
@@ -531,6 +538,13 @@ def go_dependencies():
         sum = "h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=",
         version = "v1.1.1",
     )
+    go_repository(
+        name = "com_github_gorilla_handlers",
+        importpath = "github.com/gorilla/handlers",
+        sum = "h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=",
+        version = "v1.5.1",
+    )
+
     go_repository(
         name = "com_github_gorilla_mux",
         importpath = "github.com/gorilla/mux",

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/dgraph-io/badger/v3 v3.2011.1
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/context v1.1.1
+	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/prometheus/client_golang v1.9.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrp
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
+github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db h1:gb2Z18BhTPJPpLQWj4T+rfKHYCHxRHCtRxhKKjRidVw=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8 h1:a9ENSRDFBUPkJ5lCgVZh26+ZbGyoVJG7yb5SSzF5H54=
@@ -236,6 +238,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.6.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=

--- a/services/metadata/backend/fake-backend/data/awg-metadata.json
+++ b/services/metadata/backend/fake-backend/data/awg-metadata.json
@@ -1,0 +1,828 @@
+{
+    "projectsMetadata": [
+        {
+            "type": "http://ns.dasch.swiss/repository#Dataset",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-dataset-000",
+            "abstract": [
+                "The dataset contains content-related and contextual data created and maintained within the SALSAH database as part of the editorial and documentary work of the Anton Webern Gesamtausgabe."
+            ],
+            "conditionsOfAccess": "Restricted",
+            "howToCite": "https://www.anton-webern.ch/index.php?id=85",
+            "language": [
+                "German"
+            ],
+            "license": [
+                {
+                    "name": "Creative Commons",
+                    "type": "https://schema.org/URL",
+                    "url": "https://creativecommons.org/licenses/by-sa/4.0/deed.de"
+                }
+            ],
+            "qualifiedAttribution": [
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "Contributor"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0806-person-004"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "Project manager"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0806-person-000"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "Creator"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0806-person-004"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "Member of the editorial management"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0806-person-001"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "Member of the editorial management"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0806-person-002"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "Creator"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0806-person-005"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "Creator"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0806-person-002"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "Contributor"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0806-person-005"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "Contributor"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0806-person-002"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "Member of the editorial management"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0806-person-000"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "Creator"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0806-person-003"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "Contributor"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0806-person-003"
+                        }
+                    ]
+                }
+            ],
+            "status": "Ongoing",
+            "title": "Salsah data of the Anton Webern Gesamtausgabe",
+            "typeOfData": [
+                "Image",
+                "Text",
+                "XML"
+            ],
+            "project": {
+                "id": "http://ns.dasch.swiss/repository#dsp-0806-project"
+            }
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-person-004",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Basel",
+                "postalCode": "CH-4051",
+                "streetAddress": "Petersgraben 27/29"
+            },
+            "email": [
+                "michael.matter@unibas.ch"
+            ],
+            "familyName": "Matter",
+            "givenName": "Michael",
+            "jobTitle": [
+                "Research associate"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-000"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-001"
+                }
+            ],
+            "sameAs": [
+                {
+                    "name": "GND",
+                    "type": "https://schema.org/URL",
+                    "url": "http://d-nb.info/gnd/1069569267"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-person-003",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Basel",
+                "postalCode": "CH-4051",
+                "streetAddress": "Petersgraben 27/29"
+            },
+            "email": [
+                "barbara.schingnitz@unibas.ch"
+            ],
+            "familyName": "Schingnitz",
+            "givenName": "Barbara",
+            "jobTitle": [
+                "Research associate"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-000"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-001"
+                }
+            ],
+            "sameAs": [
+                {
+                    "name": "GND",
+                    "type": "https://schema.org/URL",
+                    "url": "http://d-nb.info/gnd/130219827"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Grant",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-grant-003",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-003"
+                }
+            ],
+            "name": "Projektförderung (spezial) [2012–2015]",
+            "number": "143565",
+            "url": [
+                {
+                    "name": "snf.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "http://p3.snf.ch/Project-143565"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Grant",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-grant-002",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-003"
+                }
+            ],
+            "name": "Projektförderung (spezial) [2015–2017]",
+            "number": "162871",
+            "url": [
+                {
+                    "name": "snf.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "http://p3.snf.ch/Project-162871"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-002",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Basel",
+                "postalCode": "CH-4051",
+                "streetAddress": "Münsterplatz 4"
+            },
+            "email": "office-pss@unibas.ch",
+            "name": [
+                "Paul Sacher Stiftung",
+                "PSS"
+            ],
+            "url": [
+                {
+                    "name": "paul-sacher-stiftung.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "https://paul-sacher-stiftung.ch"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-person-001",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Basel",
+                "postalCode": "CH-4051",
+                "streetAddress": "Münsterplatz 4"
+            },
+            "email": [
+                "simon.obert@unibas.ch"
+            ],
+            "familyName": "Obert",
+            "givenName": "Simon",
+            "jobTitle": [
+                "Research associate (PSS)",
+                "Member of the editorial management",
+                "Curator"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-002"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-000"
+                }
+            ],
+            "sameAs": [
+                {
+                    "name": "GND",
+                    "type": "https://schema.org/URL",
+                    "url": "http://d-nb.info/gnd/102645249X"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#DataManagementPlan",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-dmp",
+            "isAvailable": true
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Grant",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-grant-004",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-003"
+                }
+            ],
+            "name": "Projektförderung (Abt. I-III) [2009–2012]",
+            "number": "126789",
+            "url": [
+                {
+                    "name": "snf.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "http://p3.snf.ch/Project-126789 "
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-003",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Bern",
+                "postalCode": "CH-3001",
+                "streetAddress": "Wildhainweg 3 (Postfach)"
+            },
+            "email": "com@snf.ch",
+            "name": [
+                "SNF",
+                "Schweizerischer Nationalfonds zur Förderung der wissenschaftlichen Forschung"
+            ],
+            "url": [
+                {
+                    "name": "snf.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "http://www.snf.ch"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-person-002",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Basel",
+                "postalCode": "CH-4051",
+                "streetAddress": "Petersgraben 27/29"
+            },
+            "email": [
+                "thomas.ahrend@unibas.ch"
+            ],
+            "familyName": "Ahrend",
+            "givenName": "Thomas",
+            "jobTitle": [
+                "Research associate",
+                "Member of the editorial management"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-000"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-001"
+                }
+            ],
+            "sameAs": [
+                {
+                    "name": "GND",
+                    "type": "https://schema.org/URL",
+                    "url": "http://d-nb.info/gnd/129772429"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Grant",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-grant-007",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-005"
+                }
+            ],
+            "name": "[2010–2012]",
+            "number": "E09_471",
+            "url": [
+                {
+                    "name": "evs-musikstiftung.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "https://www.evs-musikstiftung.ch/de/preise/preise/archiv/foerderprojekte/2011/publikationentagungen/historisch-kritische-gesamtausgabe"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-005",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Zug",
+                "postalCode": "CH-6300",
+                "streetAddress": "Landis + Gyr-Strasse 1"
+            },
+            "email": "rossnagl@evs-musikstiftung.ch",
+            "name": [
+                "EvS",
+                "Ernst von Siemens Musikstiftung"
+            ],
+            "url": [
+                {
+                    "name": "evs-musikstiftung.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "https://www.evs-musikstiftung.ch"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Grant",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-grant-006",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-005"
+                }
+            ],
+            "name": "[2014–2016]",
+            "number": "E13_1003",
+            "url": [
+                {
+                    "name": "evs-musikstiftung.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "https://www.evs-musikstiftung.ch/de/preise/preise/foerderprojekte/symposienpublikationen/anton-webern-briefwechsel-mit-der-universal-0"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Grant",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-grant-001",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-003"
+                }
+            ],
+            "name": "Editionen [2017–2020]",
+            "number": "157968",
+            "url": [
+                {
+                    "name": "snf.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "http://p3.snf.ch/Project-157968 "
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-person-005",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Basel",
+                "postalCode": "CH-4051",
+                "streetAddress": "Petersgraben 27/29"
+            },
+            "email": [
+                "stefan.muennich@unibas.ch"
+            ],
+            "familyName": "Münnich",
+            "givenName": "Stefan",
+            "jobTitle": [
+                "Research associate"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-000"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-001"
+                }
+            ],
+            "sameAs": [
+                {
+                    "name": "ORCID",
+                    "type": "https://schema.org/URL",
+                    "url": "https://orcid.org/0000-0002-0744-5374"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Grant",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-grant-000",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-004"
+                }
+            ],
+            "name": "Editionen [2021–2024]"
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-001",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Basel",
+                "postalCode": "CH-4051",
+                "streetAddress": "Petersgraben 27/29"
+            },
+            "email": "sekretariat-mws@unibas.ch",
+            "name": [
+                "Musikwissenschaftliches Seminar der Universität Basel",
+                "MWS"
+            ],
+            "url": [
+                {
+                    "name": "unibas.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "https://mws.unibas.ch/"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Project",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-project",
+            "contactPoint": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-000"
+                }
+            ],
+            "dataManagementPlan": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-dmp"
+                }
+            ],
+            "description": "The Anton Webern Gesamtausgabe (AWG) is a critical-historical edition which aims to make Webern’s entire oeuvre accessible to musical scholarship and practice in a scholarly form. The edition includes not only all the works Webern himself had forwarded to be printed but also their unpublished variants. It also includes compositions that were never made public in his lifetime, works from his youth and student years, as well as fragments, sketches, arrangements and revisions of his and other scores.",
+            "discipline": [
+                {
+                    "name": "SKOS UNESCO Nomenclature",
+                    "type": "https://schema.org/URL",
+                    "url": "http://skos.um.es/unesco6/620306"
+                },
+                {
+                    "name": "SKOS UNESCO Nomenclature",
+                    "type": "https://schema.org/URL",
+                    "url": "http://skos.um.es/unesco6/620201"
+                }
+            ],
+            "endDate": "2024-12-31",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-003"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-004"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-005"
+                }
+            ],
+            "grant": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-grant-004"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-grant-002"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-grant-007"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-grant-001"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-grant-005"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-grant-000"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-grant-003"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-grant-006"
+                }
+            ],
+            "keywords": [
+                "semantic web",
+                "philology",
+                "Viennese school",
+                "source studies",
+                "Anton Webern",
+                "Gesamtausgabe",
+                "musicology",
+                "textual criticism",
+                "digital music edition",
+                "critical edition"
+            ],
+            "name": "Anton Webern Gesamtausgabe",
+            "publication": [
+                "https://www.anton-webern.ch/index.php?id=87"
+            ],
+            "shortcode": "0806",
+            "spatialCoverage": [
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/countries/HR/croatia.html"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/12217934/baltic-states.html"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/countries/US/united-states.html"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/countries/FR/france.html"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/countries/PL/poland.html"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/countries/ES/spain.html"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/countries/SK/slovakia.html"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/countries/CH/switzerland.html"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/countries/GB/united-kingdom.html"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/countries/DE/germany.html"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/countries/HU/hungary.html"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/countries/AT/austria.html"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/countries/SI/slovenia.html"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/countries/IT/italy.html"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/countries/CZ/czechia.html"
+                    }
+                }
+            ],
+            "startDate": "2006-10-01",
+            "temporalCoverage": [
+                "1850–today"
+            ],
+            "url": [
+                {
+                    "name": "anton-webern.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "https://www.anton-webern.ch"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-004",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Bern",
+                "postalCode": "CH-3001",
+                "streetAddress": "Laupenstrasse 7 (Postfach)"
+            },
+            "email": "sagw@sagw.ch",
+            "name": [
+                "SAGW",
+                "Schweizerische Akademie der Geistes- und Sozialwissenschaften"
+            ],
+            "url": [
+                {
+                    "name": "sagw.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "https://sagw.ch/"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-000",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Basel",
+                "postalCode": "CH-4051",
+                "streetAddress": "Petersgraben 27/29"
+            },
+            "email": "info-awg@unibas.ch",
+            "name": [
+                "Anton Webern Gesamtausgabe",
+                "AWG"
+            ],
+            "url": [
+                {
+                    "name": "anton-webern.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "https://www.anton-webern.ch"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-person-000",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Basel",
+                "postalCode": "CH-4051",
+                "streetAddress": "Petersgraben 27/29"
+            },
+            "email": [
+                "matthias.schmidt@unibas.ch"
+            ],
+            "familyName": "Schmidt",
+            "givenName": "Matthias",
+            "jobTitle": [
+                "Full professor",
+                "Member of the editorial management",
+                "Project manager"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-000"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-001"
+                }
+            ],
+            "sameAs": [
+                {
+                    "name": "GND",
+                    "type": "https://schema.org/URL",
+                    "url": "http://d-nb.info/gnd/12307195X"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Grant",
+            "id": "http://ns.dasch.swiss/repository#dsp-0806-grant-005",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0806-organization-003"
+                }
+            ],
+            "name": "Projektförderung (Abt. I-III) [2006–2009]",
+            "number": "113769",
+            "url": [
+                {
+                    "name": "snf.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "http://p3.snf.ch/Project-113769"
+                }
+            ]
+        }
+    ]
+}

--- a/services/metadata/backend/fake-backend/data/beol-metadata.json
+++ b/services/metadata/backend/fake-backend/data/beol-metadata.json
@@ -1,0 +1,513 @@
+{
+    "projectsMetadata": [
+        {
+            "type": "http://ns.dasch.swiss/repository#Dataset",
+            "id": "http://ns.dasch.swiss/repository#dsp-0801-dataset-001",
+            "abstract": [
+                {
+                    "name": "dasch.swiss",
+                    "type": "https://schema.org/URL",
+                    "url": "http://ark.dasch.swiss/ark:/72163/1/0801/4UDRwNHCQZWhJZdL=JfBSAt.20191028T094815009Z"
+                }
+            ],
+            "alternativeTitle": "Condorcet-Turgot",
+            "conditionsOfAccess": "open",
+            "howToCite": "Bernoulli-Euler Online (BEOL), 2019, DaSCH. https://beol.dasch.swiss",
+            "language": [
+                "French"
+            ],
+            "license": [
+                {
+                    "name": "Creative Commons",
+                    "type": "https://schema.org/URL",
+                    "url": "https://creativecommons.org/licenses/by-nc-nd/4.0/"
+                }
+            ],
+            "qualifiedAttribution": [
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "author"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0801-person-005"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "author"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0801-person-004"
+                        }
+                    ]
+                }
+            ],
+            "status": "Finished",
+            "title": "Briefwechsel von Euler mit Condoret und Turgot",
+            "typeOfData": [
+                "Image",
+                "Text",
+                "XML"
+            ],
+            "project": {
+                "id": "http://ns.dasch.swiss/repository#dsp-0801-project"
+            }
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Dataset",
+            "id": "http://ns.dasch.swiss/repository#dsp-0801-dataset-000",
+            "abstract": [
+                {
+                    "name": "dasch.swiss",
+                    "type": "https://schema.org/URL",
+                    "url": "http://ark.dasch.swiss/ark:/72163/1/0801/18ngnZB9Sgy2PlOl71OJxgl.20191028T094314789Z"
+                }
+            ],
+            "conditionsOfAccess": "open",
+            "howToCite": "Bernoulli-Euler Online (BEOL), 2019, DaSCH. https://beol.dasch.swiss",
+            "language": [
+                "Latin",
+                "English",
+                "French",
+                "German"
+            ],
+            "license": [
+                {
+                    "name": "Creative Commons",
+                    "type": "https://schema.org/URL",
+                    "url": "https://creativecommons.org/licenses/by-nc-nd/4.0/"
+                }
+            ],
+            "qualifiedAttribution": [
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "author"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0801-person-001"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "author"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0801-person-000"
+                        }
+                    ]
+                }
+            ],
+            "status": "Finished",
+            "title": "Briefwechsel von Leonhard Euler mit Christian Goldbach",
+            "typeOfData": [
+                "Image",
+                "Text",
+                "XML"
+            ],
+            "project": {
+                "id": "http://ns.dasch.swiss/repository#dsp-0801-project"
+            }
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Dataset",
+            "id": "http://ns.dasch.swiss/repository#dsp-0801-dataset-003",
+            "abstract": [
+                {
+                    "name": "unibas.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "https://bez.unibas.ch/de/basler-edition-der-bernoulli-briefwechsel/"
+                }
+            ],
+            "alternativeTitle": "BEBB",
+            "conditionsOfAccess": "open",
+            "dateCreated": "2018-01-01",
+            "dateModified": "2018-01-01",
+            "datePublished": "2018-01-01",
+            "howToCite": "Bernoulli-Euler Online (BEOL), 2019, DaSCH. https://beol.dasch.swiss",
+            "language": [
+                "Latin",
+                "French",
+                "German"
+            ],
+            "license": [
+                {
+                    "name": "Creative Commons",
+                    "type": "https://schema.org/URL",
+                    "url": "https://creativecommons.org/licenses/by-nc-nd/4.0/"
+                }
+            ],
+            "qualifiedAttribution": [
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "author"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0801-person-003"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "author"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0801-person-002"
+                        }
+                    ]
+                }
+            ],
+            "status": "Ongoing",
+            "title": "Basler Edition der Bernoulli-Briefwechsel ",
+            "typeOfData": [
+                "Image",
+                "Text"
+            ],
+            "project": {
+                "id": "http://ns.dasch.swiss/repository#dsp-0801-project"
+            }
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Dataset",
+            "id": "http://ns.dasch.swiss/repository#dsp-0801-dataset-002",
+            "abstract": [
+                "Edition of Jacob Bernoulli's Scientific Notebook (Meditationes)."
+            ],
+            "alternativeTitle": "Meditationes",
+            "conditionsOfAccess": "open",
+            "howToCite": "Bernoulli-Euler Online (BEOL), 2019, DaSCH. https://beol.dasch.swiss",
+            "language": [
+                "Latin",
+                "English",
+                "German"
+            ],
+            "license": [
+                {
+                    "name": "Creative Commons",
+                    "type": "https://schema.org/URL",
+                    "url": "https://creativecommons.org/licenses/by-nc-nd/4.0/"
+                }
+            ],
+            "qualifiedAttribution": [
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "author"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-0801-person-000"
+                        }
+                    ]
+                }
+            ],
+            "status": "Finished",
+            "title": "Jacob Bernoulli's Scientific Notebook (Meditationes)",
+            "typeOfData": [
+                "Image",
+                "Text",
+                "XML"
+            ],
+            "project": {
+                "id": "http://ns.dasch.swiss/repository#dsp-0801-project"
+            }
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-0801-organization-002",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Bern",
+                "postalCode": "3001",
+                "streetAddress": "Haus der Akademien, Postfach"
+            },
+            "email": "sagw@sagw.ch",
+            "name": [
+                "Schweizerische Akademie der Geisteswissenschaften (SAGW)"
+            ],
+            "url": [
+                {
+                    "name": "sagw.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "https://sagw.ch/"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-0801-organization-000",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Bern",
+                "postalCode": "3001",
+                "streetAddress": "Wildhainweg 3, Postfach"
+            },
+            "email": "desk@snf.ch",
+            "name": [
+                "Schweizerischer Nationalfonds (SNF)"
+            ],
+            "url": [
+                {
+                    "name": "snf.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "http://www.snf.ch/"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-0801-person-000",
+            "email": [
+                "martin.mattmueller@unibas.ch"
+            ],
+            "familyName": "Mattmüller",
+            "givenName": "Martin",
+            "jobTitle": [
+                "Wissenschaftlicher Mitarbeiter"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0801-organization-003"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-0801-person-001",
+            "familyName": "Lemmermeyer",
+            "givenName": "Franz",
+            "jobTitle": [
+                "Mathematiker"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0801-organization-003"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Project",
+            "id": "http://ns.dasch.swiss/repository#dsp-0801-project",
+            "alternateName": [
+                "BEOL"
+            ],
+            "description": "The project Bernoulli-Euler Online (BEOL) integrates the two edition projects Basler Edition der Bernoulli-Briefwechsel (BEBB) and Leonhardi Euleri Opera Omnia (LEOO) into one digital platform available on the web. In addition, Jacob Bernoulli's scientific notebook Meditationes - a document of outstanding significance for the history of mathematics at its turning point around 1700 - is published for the first time in its entirety on the BEOL platform as a region-based multilayer interactive digital edition providing access to facsimiles, transcriptions, translations, indices, and commentaries. Besides being an edition platform, BEOL is a virtual research environment for the study of early modern mathematics and science as a data graph using sophisticated analysis tools. Currently BEOL is connected to two third-party repositories: The Newton Project and the Briefportal Leibniz, initiating the formation of a network of digital editions of the early modern scientific correspondence data. The goal of BEOL is thus twofold: it focuses on the mathematics influenced by the Bernoulli dynasty and Leonhard Euler and undertakes a methodological effort to present these materials to the public and researchers in a highly functional way.",
+            "discipline": [
+                {
+                    "name": "SKOS UNESCO Nomenclature",
+                    "type": "https://schema.org/URL",
+                    "url": "http://skos.um.es/unesco6/12"
+                }
+            ],
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0801-organization-000"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0801-organization-002"
+                }
+            ],
+            "grant": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0801-grant-000"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0801-grant-001"
+                }
+            ],
+            "keywords": [
+                "Leibniz",
+                "Science",
+                "Turgot",
+                "Euler",
+                "Bernoulli",
+                "Condorcet",
+                "Mathematics",
+                "history of science",
+                "Goldbach",
+                "Newton",
+                "history of mathematics"
+            ],
+            "name": "Bernoulli-Euler Online (BEOL)",
+            "shortcode": "0801",
+            "spatialCoverage": [
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/11961320"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/2658434"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/6255148"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/3017382"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/3175395"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/2635167"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/2921044"
+                    }
+                }
+            ],
+            "startDate": "2016-07-01",
+            "temporalCoverage": [
+                "17th century and18th century CE"
+            ],
+            "url": [
+                {
+                    "name": "dasch.swiss",
+                    "type": "https://schema.org/URL",
+                    "url": "https://beol.dasch.swiss/"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-0801-person-004",
+            "familyName": "Gilan",
+            "givenName": "Christian",
+            "jobTitle": [
+                "Professor"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0801-organization-003"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-0801-person-003",
+            "email": [
+                "sulamith.gehr@unibas.ch"
+            ],
+            "familyName": "Gehr",
+            "givenName": "Sulamith",
+            "jobTitle": [
+                "Wissenschaftliche Mitarbeiterin"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0801-organization-003"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-0801-person-005",
+            "familyName": "Hug",
+            "givenName": "Vanja",
+            "jobTitle": [
+                "Dr. phil. Historikerin"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0801-organization-003"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-0801-person-002",
+            "email": [
+                "fritz.nagel@unibas.ch"
+            ],
+            "familyName": "Nagel",
+            "givenName": "Fritz",
+            "jobTitle": [
+                "Leiter Bernoulli-Archiv"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0801-organization-003"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Grant",
+            "id": "http://ns.dasch.swiss/repository#dsp-0801-grant-001",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0801-organization-002"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Grant",
+            "id": "http://ns.dasch.swiss/repository#dsp-0801-grant-000",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-0801-organization-000"
+                }
+            ],
+            "name": "Projektförderung (Abt. I-III)",
+            "number": "166072",
+            "url": [
+                {
+                    "name": "snf.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "http://p3.snf.ch/project-166072"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-0801-organization-003",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Basel",
+                "postalCode": "4056",
+                "streetAddress": "Universitätsbibliothek, Schönbeinstrasse 18-20"
+            },
+            "email": "bez@unibas.ch",
+            "name": [
+                "Bernoulli-Euler-Zentrum"
+            ],
+            "url": [
+                {
+                    "name": "bez.unibas.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "https://www.bez.unibas.ch"
+                }
+            ]
+        }
+    ]
+}

--- a/services/metadata/backend/fake-backend/data/big-dada-in-agriculture-metadata.json
+++ b/services/metadata/backend/fake-backend/data/big-dada-in-agriculture-metadata.json
@@ -1,0 +1,230 @@
+{
+    "projectsMetadata": [
+        {
+            "type": "http://ns.dasch.swiss/repository#Dataset",
+            "id": "http://ns.dasch.swiss/repository#dsp-082D-dataset-001",
+            "abstract": [
+                "Smart technologies transform farming today. Think of autonomous tractors and weeding robots, animals and underground infrastructures with inbuilt sensors, and drones or satellites offering image analysis from the air. There are many opportunities arising from this evolution in terms of increased productivity, profitability, and sustainability. Critical issues, in turn, include techno-dependency, vulnerability and privacy. This project contributes empirical evidence to the discussion of the opportunities and risks associated with smart farming. It starts from the assumption that smart farming – i.e. the management of agricultural practices and processes through techniques of data gathering, transfer and analysis – is never neutral, but shaped by all kinds of decisions and judgements built into the systems from their very elaboration. The project thus studies ‘what lies behind’ novel smart-farming solutions, looking at where, by whom and how they are produced and subsequently diffused as exemplars to follow. It does so through the investigation of two high-profile initiatives in Switzerland: Swiss Future Farm: An experimental and demonstration farm, set up on Agroscope’s test site in Tänikon (TG) as a joint public–private initiative, to be inaugurated on 21 September 2018. AgroFly’s (now with Aero41) sprayer-drone project (Sierre, VS): The first authorized drone system in Europe for the automated application of pesticides. Test sites are distributed in Switzerland and beyond. This project claims that specific initiatives, anchored in specific sites of experimentation, play a fundamental role in assembling the actor networks that carry forward the evolutions around smart farming. Grounded in Actor Network Theory, the project unpacks the chain of mediations through which relevant actors, ideas and things connect and interact in the co-production of the studied initiatives, and investigates the relationships and mechanisms that tie them to each other and to other sites and initiatives. There are four interrelated research objectives that run through this investigation, relating to the collaborative, expertise-related, discursive, and spatial dimensions of learning and exemplification: to analyse the practices of collaboration through which novel smart-farming solutions are developed and stabilized for more normalized use through the studied sites of experimentation. to examine what and how specific forms of expertise become authorized to act in the different stages and chains of mediation associated with the studied sites. to investigate what and how specific discourses, expectations and beliefs surrounding smart technologies crystallize in and emerge from the studied initiatives. to explore the forces and mechanisms through which the studied sites are tied to other places and projects in the circuits of learning and exemplification that shape the field of smart farming. To pursue these objectives, the project follows three methodological pathways: textual analysis of literature and reports, non-participant observation, and semi-structured interviews. This approach is exploratory in ambition and scope and leads to further, follow-up research proposals on Big Data in agriculture. On these grounds, the project studies, informs and debates innovation in the agricultural sector. It highlights the factors that favour or hinder technology innovation, diffusion and adaptation, and fosters greater understanding about the desirability or non-desirability of this. User beneficiaries include farmers and farming associations, technology  "
+            ],
+            "conditionsOfAccess": "Restricted",
+            "howToCite": "Klauser FR and Pauschinger D (2020) Big Data in Agriculture: The Making of Smart Farms, SNF Project Data Set.",
+            "language": [
+                "English",
+                "French",
+                "German"
+            ],
+            "license": [
+                {
+                    "name": "creativecommons.org",
+                    "type": "https://schema.org/URL",
+                    "url": "https://creativecommons.org/licenses/by-nc-sa/4.0/"
+                }
+            ],
+            "qualifiedAttribution": [
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "PI"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-082D-person-001"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "Senior Research Fellow"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-082D-person-002"
+                        }
+                    ]
+                }
+            ],
+            "status": "Finished",
+            "title": "Dataset of Big Data in Agriculture: The Making of Smart Farms",
+            "typeOfData": [
+                "Text"
+            ],
+            "project": {
+                "id": "http://ns.dasch.swiss/repository#dsp-082D-project"
+            }
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Project",
+            "id": "http://ns.dasch.swiss/repository#dsp-082D-project",
+            "contactPoint": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082D-person-001"
+                }
+            ],
+            "dataManagementPlan": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dmp"
+                }
+            ],
+            "description": "Smart technologies transform farming today. Think of autonomous tractors and weeding robots, animals and underground infrastructures with inbuilt sensors, and drones or satellites offering image analysis from the air. There are many opportunities arising from this evolution in terms of increased productivity, profitability, and sustainability. Critical issues, in turn, include techno-dependency, vulnerability and privacy.\nThis project contributes empirical evidence to the discussion of the opportunities and risks associated with smart farming. It starts from the assumption that smart farming – i.e. the management of agricultural practices and processes through techniques of data gathering, transfer and analysis – is never neutral, but shaped by all kinds of decisions and judgements built into the systems from their very elaboration. The project thus studies ‘what lies behind’ novel smart-farming solutions, looking at where, by whom and how they are produced and subsequently diffused as exemplars to follow. It does so through the investigation of two high-profile initiatives in Switzerland:\nSwiss Future Farm: An experimental and demonstration farm, set up on Agroscope’s test site in Tänikon (TG) as a joint public–private initiative, to be inaugurated on 21 September 2018.\nAgroFly’s (now with Aero41) sprayer-drone project (Sierre, VS): The first authorized drone system in Europe for the automated application of pesticides. Test sites are distributed in Switzerland and beyond.\nThis project claims that specific initiatives, anchored in specific sites of experimentation, play a fundamental role in assembling the actor networks that carry forward the evolutions around smart farming. Grounded in Actor Network Theory, the project unpacks the chain of mediations through which relevant actors, ideas and things connect and interact in the co-production of the studied initiatives, and investigates the relationships and mechanisms that tie them to each other and to other sites and initiatives. There are four interrelated research objectives that run through this investigation, relating to the collaborative, expertise-related, discursive, and spatial dimensions of learning and exemplification:\nto analyse the practices of collaboration through which novel smart-farming solutions are developed and stabilized for more normalized use through the studied sites of experimentation.\nto examine what and how specific forms of expertise become authorized to act in the different stages and chains of mediation associated with the studied sites.\nto investigate what and how specific discourses, expectations and beliefs surrounding smart technologies crystallize in and emerge from the studied initiatives.\nto explore the forces and mechanisms through which the studied sites are tied to other places and projects in the circuits of learning and exemplification that shape the field of smart farming.\nTo pursue these objectives, the project follows three methodological pathways: textual analysis of literature and reports, non-participant observation, and semi-structured interviews. This approach is exploratory in ambition and scope and leads to further, follow-up research proposals on Big Data in agriculture. On these grounds, the project studies, informs and debates innovation in the agricultural sector. It highlights the factors that favour or hinder technology innovation, diffusion and adaptation, and fosters greater understanding about the desirability or non-desirability of this. User beneficiaries include farmers and farming associations, technology ",
+            "discipline": [
+                {
+                    "name": "SKOS UNESCO Nomenclature",
+                    "type": "https://schema.org/URL",
+                    "url": "http://skos.um.es/unesco6/540305"
+                }
+            ],
+            "endDate": "2020-06-30",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082D-organization-001"
+                }
+            ],
+            "grant": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082D-grant-001"
+                }
+            ],
+            "keywords": [
+                "Big Data",
+                "Agriculture",
+                "Smart Farming",
+                "Drohnen",
+                "Swiss Future Farm"
+            ],
+            "name": "Big Data in Agriculture: The Making of Smart Farms",
+            "publication": [
+                "Klauser, FR.: Surveillance Farms: Towards a Research Agenda on Big Data in Agriculture, Surveillance & Society, 16(3), 370-378, https://doi.org/10.24908/ss.v16i3.12594, 2020. ",
+                "Pauschinger, D. and Klauser, F.: Räume des Experimentierens: Die Einführung von Sprühdrohnen in der digitalen Landwirtschaft, Geogr. Helv., 75, 325–336, https://doi.org/10.5194/gh-75-325-2020, 2020. "
+            ],
+            "shortcode": "082D",
+            "spatialCoverage": [
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/2658434/switzerland.html"
+                    }
+                }
+            ],
+            "startDate": "2018-12-01",
+            "temporalCoverage": [
+                {
+                    "name": "dainst.org",
+                    "type": "https://schema.org/URL",
+                    "url": "https://chronontology.dainst.org/period/8bGPuf5syqCD"
+                }
+            ],
+            "url": [
+                {
+                    "name": "unine.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "http://www.unine.ch/geographie/en/home/recherche/--espace-et-pouvoir-a-lere-du-nu/research-projects/smart-farming.html"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#DataManagementPlan",
+            "id": "http://ns.dasch.swiss/repository#dmp",
+            "isAvailable": true
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-082D-organization-002",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Neuchâtel",
+                "postalCode": "2000",
+                "streetAddress": "Espace Tilo-Frey 1"
+            },
+            "email": "Secretariat.Geographie@unine.ch ",
+            "name": [
+                "Université de Neuchâtel, Faculté des lettres et sciences humaines"
+            ],
+            "url": [
+                {
+                    "name": "unine.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "http://www.unine.ch/geographie/home.html"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-082D-organization-001",
+            "name": [
+                "Swiss National Science Foundation"
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-082D-person-002",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Neuchâtel",
+                "postalCode": "2000",
+                "streetAddress": "Espace Tilo-Frey 1"
+            },
+            "email": [
+                "dennis.pauschinger@unine.ch"
+            ],
+            "familyName": "Pauschinger",
+            "givenName": "Dennis",
+            "jobTitle": [
+                "Postdoc "
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082D-organization-002"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-082D-person-001",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Neuchâtel",
+                "postalCode": "2000",
+                "streetAddress": "Espace Tilo-Frey 1"
+            },
+            "email": [
+                "francisco.klauser@unine.ch"
+            ],
+            "familyName": "Klauser",
+            "givenName": "Francisco R.",
+            "jobTitle": [
+                "Full professor of political geography"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082D-organization-002"
+                }
+            ],
+            "sameAs": [
+                {
+                    "name": "orcid.org",
+                    "type": "https://schema.org/URL",
+                    "url": "https://orcid.org/0000-0003-3383-3570."
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Grant",
+            "id": "http://ns.dasch.swiss/repository#dsp-082D-grant-001",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082D-organization-001"
+                }
+            ],
+            "name": "Digital Lives",
+            "number": "FN 10DL1A_183037",
+            "url": [
+                {
+                    "name": "snf.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "http://www.snf.ch/de/foerderung/projekte/digital-lives/Seiten/default.aspx"
+                }
+            ]
+        }
+    ]
+}

--- a/services/metadata/backend/fake-backend/data/cache-metadata.json
+++ b/services/metadata/backend/fake-backend/data/cache-metadata.json
@@ -1,0 +1,474 @@
+{
+    "projectsMetadata": [
+        {
+            "type": "http://ns.dasch.swiss/repository#Dataset",
+            "id": "http://ns.dasch.swiss/repository#dsp-082B-dataset-001",
+            "abstract": [
+                "Genetic engineering, acid rain, nuclear accidents, ozone depletion, computerization — in the years around 1980, science moved center-stage as a socio-political quandary. First and foremost, it were the new social movements that cultivated critiques of science and technology; but soon enough, the desire for an alternative science, or a “counter-knowledge”, diffused into the broader realms of politics, economics and, not least, establishment science. What was this “counter\"-science? Where did it succeed? Where did it fail? And why is this relevant again today?"
+            ],
+            "conditionsOfAccess": "Open",
+            "datePublished": "2020-10-01",
+            "howToCite": "Gegen|Wissen, intercom: Zürich (2020)",
+            "language": [
+                "English",
+                "German"
+            ],
+            "license": [
+                {
+                    "name": "creativecommons.org",
+                    "type": "https://schema.org/URL",
+                    "url": "https://creativecommons.org/licenses/by-nc-nd/4.0/"
+                }
+            ],
+            "qualifiedAttribution": [
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "author"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-008"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "publisher"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-002"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "author"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-007"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "scientific direction"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-003"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "author"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-009"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "project lead"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-001"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "author"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-012"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "author"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-011"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "author"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-006"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "author"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-004"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "author"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-010"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "editorial management"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-002"
+                        }
+                    ]
+                },
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "author"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-005"
+                        }
+                    ]
+                }
+            ],
+            "status": "Finished",
+            "title": "Gegen|Wissen (cache 01)",
+            "typeOfData": [
+                "Text"
+            ],
+            "project": {
+                "id": "http://ns.dasch.swiss/repository#dsp-082B-project"
+            },
+            "sameAs": [
+                {
+                    "name": "www.cache.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "www.cache.ch/gegenwissen"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Project",
+            "id": "http://ns.dasch.swiss/repository#dsp-082B-project",
+            "contactPoint": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-002"
+                }
+            ],
+            "description": "cache is a hybrid publication tool for research groups in the humanities.",
+            "discipline": [
+                "10400 Ethnologie, Sozial- und Humangeographie ",
+                "10301 Allgemeine Geschichte (ohne Ur- und Frühgeschichte)",
+                "10302 Schweizer Geschichte",
+                "10600 Soziologie, Soziale Arbeit, Politikwissenschaften, Medien- und Kommunikationswissenschaften, Gesundheit"
+            ],
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-003"
+                }
+            ],
+            "grant": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082B-grant-001"
+                }
+            ],
+            "keywords": [
+                "humanities",
+                "academic publishing"
+            ],
+            "name": "cache",
+            "publication": [
+                "Gegen|Wissen (cache 01)"
+            ],
+            "shortcode": "082B",
+            "spatialCoverage": [
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/countries/"
+                    }
+                }
+            ],
+            "startDate": "2018-12-01",
+            "temporalCoverage": [
+                "19th Century",
+                "20th Century",
+                "16th Century",
+                "17th Century",
+                "18th Century"
+            ],
+            "url": [
+                {
+                    "name": "www.cache.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "www.cache.ch"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-009",
+            "familyName": "Schmidt",
+            "givenName": "Susanne",
+            "jobTitle": [
+                "Historian"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-001"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-011",
+            "familyName": "Wulz",
+            "givenName": "Monika",
+            "jobTitle": [
+                "Historian"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-001"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-007",
+            "familyName": "Schlünder",
+            "givenName": "Martina",
+            "jobTitle": [
+                "Historian"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-001"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-004",
+            "familyName": "Grote",
+            "givenName": "Mathias",
+            "jobTitle": [
+                "Historian"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-001"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-005",
+            "familyName": "Grütter",
+            "givenName": "Fabian",
+            "jobTitle": [
+                "Historian"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-001"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-008",
+            "familyName": "Schmidt",
+            "givenName": "Anna Maria",
+            "jobTitle": [
+                "Historian"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-001"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-006",
+            "familyName": "Scheidegger",
+            "givenName": "Tobias",
+            "jobTitle": [
+                "Historian"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-001"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-003",
+            "email": [
+                "mxmlnstdlr@gmail.com"
+            ],
+            "familyName": "Stadler",
+            "givenName": "Max",
+            "jobTitle": [
+                "Historian"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-001"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Grant",
+            "id": "http://ns.dasch.swiss/repository#dsp-082B-grant-001",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-003"
+                }
+            ],
+            "name": "Digital Lives SNF",
+            "number": "http://p3.snf.ch/Project-183057",
+            "url": [
+                {
+                    "name": "183057",
+                    "type": "https://schema.org/URL",
+                    "url": "183057"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-001",
+            "email": [
+                "nils.guettler@wiss.gess.ethz.ch"
+            ],
+            "familyName": "Güttler",
+            "givenName": "Nils",
+            "jobTitle": [
+                "Historian"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-001"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-002",
+            "email": [
+                "niki.rhyner@wiss.gess.ethz.ch"
+            ],
+            "familyName": "Rhyner",
+            "givenName": "Niki",
+            "jobTitle": [
+                "Historian"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-001"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-010",
+            "familyName": "von Schwerin",
+            "givenName": "Alexander",
+            "jobTitle": [
+                "Historian"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-001"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-001",
+            "name": [
+                "ETH Zurich"
+            ],
+            "url": [
+                {
+                    "name": "www.ethz.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "www.ethz.ch"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-002",
+            "email": "info@intercomverlag.ch",
+            "name": [
+                "intercom Verlag"
+            ],
+            "url": [
+                {
+                    "name": "www.intercom",
+                    "type": "https://schema.org/URL",
+                    "url": "www.intercomverlag.ch"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Person",
+            "id": "http://ns.dasch.swiss/repository#dsp-082B-person-012",
+            "familyName": "Zberg",
+            "givenName": "Nadine",
+            "jobTitle": [
+                "Historian"
+            ],
+            "memberOf": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-001"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-082B-organization-003",
+            "name": [
+                "SNSF"
+            ]
+        }
+    ]
+}

--- a/services/metadata/backend/fake-backend/data/drawings-metadata.json
+++ b/services/metadata/backend/fake-backend/data/drawings-metadata.json
@@ -1,0 +1,624 @@
+{
+  "projectsMetadata": [
+    {
+      "type": "http://ns.dasch.swiss/repository#Dataset",
+      "id": "http://ns.dasch.swiss/repository#dsp-0105-dataset-000",
+      "abstract": [
+        "Au cours des dernières décennies l’étude du concept de dieu (ainsi que l’image et la représentation) est devenu l’un des principaux domaines de recherche en psychologie de la religion. Cette question a été abordée au travers de différentes approches psychologiques : la psychologie développementale cognitive, les théories de la relation d’objet, la psychologie cognitive, les théories des attributions et la théorie d’attachement. En dépit des progrès réalisés, la compréhension de ce phénomène très complexe reste toujours limitée. Selon de nombreux chercheurs une des raisons importantes est celle des méthodes utilisées qui, de façon globale, se basent sur des méthodes verbales: des questionnaires, des entretiens, des listes d’adjectifs pour décrire dieu, des associations libres, etc.  Le projet Dessins de dieux, dirigé par le professeur Pierre-Yves Brandt, vise à contribuer à une compréhension ultérieure de l’origine du concept de dieu et son développement chez les enfants. La technique de dessin, critiquée par certains chercheurs, se présente comme un outil opportun pour effectuer une étude à fois développementale et cross-culturelle. Elle est même plus efficace pour mettre en lumière la place et la fonction des images dans le processus de l’acquisition et de l’intériorisation de certains concepts religieux, ainsi que pour révéler des contradictions et des difficultés de l’acquisition de l’idée de dieu par des enfants. L’absence de telles études entrave les progrès de nos savoirs dans ce domaine.  La base de données Dessins de dieux a été créée pour stocker des données de cette recherche et les rendre accessibles non seulement aux chercheurs affiliés au projet mais aussi au grand public qui s’intéresse à cette problématique. Une première collection de 143 dessins a été récoltée en 2003-2004 au Japon. Actuellement, la base de données contient plus de 7100 dessins recueillis au Japon, en Roumanie, en Russie, en Suisse, aux États-Unis, en Iran, au Népal et aux Pays-Bas ; elle continue à s’agrandir.  Nous espérons que cette recherche intéressera les chercheurs d’autres pays afin que cette base de données s’enrichisse de dessins issus d’autres traditions confessionnelles et culturelles. "
+      ],
+      "conditionsOfAccess": "Restricted",
+      "dateCreated": "2018-07-02",
+      "dateModified": "2021-02-24",
+      "datePublished": "2018-07-02",
+      "howToCite": "Brandt, P.-Y., Serbaeva O.,  Cocco, Ch., Dessart, G., Rivoal, M.,  2019, Dessins de dieux [database] (DaSCH), http://ark.dasch.swiss/ark:/72163/1/0105.",
+      "language": [
+        "French"
+      ],
+      "license": [
+        {
+          "name": "Creative Commons",
+          "type": "https://schema.org/URL",
+          "url": "https://creativecommons.org/licenses/by-sa/4.0/"
+        }
+      ],
+      "qualifiedAttribution": [
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Data collector"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0105-person-004"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Project leader"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0105-person-003"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Project member"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0105-person-006"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Data curator"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0105-person-008"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Project leader"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0105-person-002"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Data collector"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0105-person-006"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Project leader"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0105-person-000"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Other"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0105-person-007"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Project leader"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0105-person-001"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Data curator"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0105-person-005"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Project member"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0105-person-004"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Data curator"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0105-person-006"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Data curator"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0105-person-004"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Project member"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0105-person-005"
+            }
+          ]
+        }
+      ],
+      "status": "Finished",
+      "title": "Base de données Dessins de dieux",
+      "typeOfData": [
+        "Image",
+        "Text"
+      ],
+      "project": {
+        "id": "http://ns.dasch.swiss/repository#dsp-0105-project"
+      },
+      "sameAs": [
+        {
+          "name": "unil.ch",
+          "type": "https://schema.org/URL",
+          "url": "https://ddd.unil.ch/"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0105-person-002",
+      "email": [
+        "zhargalma.dandarova@unil.ch"
+      ],
+      "familyName": "Dandarova-Robert",
+      "givenName": "Zhargalma",
+      "jobTitle": [
+        "Lecturer"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0105-organization-001"
+        }
+      ],
+      "sameAs": [
+        {
+          "name": "ORCID",
+          "type": "https://schema.org/URL",
+          "url": "https://orcid.org/0000-0003-3979-4859"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Organization",
+      "id": "http://ns.dasch.swiss/repository#dsp-0105-organization-001",
+      "address": {
+        "type": "https://schema.org/PostalAddress",
+        "addressLocality": "Lausanne",
+        "postalCode": "1015",
+        "streetAddress": "Unicentre"
+      },
+      "name": [
+        "Université de Lausanne"
+      ],
+      "url": [
+        {
+          "name": "unil.ch",
+          "type": "https://schema.org/URL",
+          "url": "https://www.unil.ch/"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Organization",
+      "id": "http://ns.dasch.swiss/repository#dsp-0105-organization-000",
+      "address": {
+        "type": "https://schema.org/PostalAddress",
+        "addressLocality": "Bern",
+        "postalCode": "3001",
+        "streetAddress": "Wildhainweg 3 Postfach"
+      },
+      "email": "desk@snf.ch",
+      "name": [
+        "Swiss National Science Foundation (SNSF)"
+      ],
+      "url": [
+        {
+          "name": "snf.ch",
+          "type": "https://schema.org/URL",
+          "url": "http://www.snf.ch/"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0105-person-001",
+      "email": [
+        "dominique.vinck@unil.ch"
+      ],
+      "familyName": "Vinck",
+      "givenName": "Dominique",
+      "jobTitle": [
+        "Full professor"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0105-organization-001"
+        }
+      ],
+      "sameAs": [
+        {
+          "name": "ORCID",
+          "type": "https://schema.org/URL",
+          "url": "https://orcid.org/0000-0001-7835-7008"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Project",
+      "id": "http://ns.dasch.swiss/repository#dsp-0105-project",
+      "alternateName": [
+        "drawings-gods"
+      ],
+      "contactPoint": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0105-person-000"
+        }
+      ],
+      "description": "La récolte de dessins constitue une technique largement éprouvée pour étudier les représentations imaginaires des enfants. Sur la base d’une collecte de plusieurs centaines de dessins dans diverses régions du monde, notamment au Brésil, en Iran, au Japon, aux Pays-Bas, en Roumanie, en Russie et en Suisse, ce projet prévoit d’étudier l’évolution de la représentation de Dieu ou d’autres êtres surnaturels (dieux, esprits, génies, etc) chez des enfants et des adolescents entre 5 et 18 ans. Il s’intéressera tout spécialement aux stratégies mises en place par les enfants : recours à des représentations religieuses traditionnelles, à des images d’êtres surnaturels véhiculées par des films d’animation ou des bandes dessinées. Au terme du projet, l’objectif est d’avoir pu décrire les stratégies principales utilisées les enfants en ayant pu mettre en évidence comment le choix d’une stratégie plutôt qu’une autre est influencé par l’âge, le sexe, l’éducation religieuse et l’environnement culturel de l’enfant.\nLe contexte de travail est interdisciplinaire. L’analyse du matériel récolté combinera traitement informatique des images et descriptions fournies par des spécialistes du développement de l’enfant, de l’étude des religions et des contextes culturels de provenance des dessins. Ces analyses d’images seront complétées par des analyses textuelles des commentaires fournis par les enfants pour expliquer ce qu’ils ont dessiné.",
+      "discipline": [
+        "http://skos.um.es/unesco6/630110 ",
+        "Sociology",
+        {
+          "name": "SKOS UNESCO Nomenclature",
+          "type": "https://schema.org/URL",
+          "url": "http://skos.um.es/unesco6/61"
+        },
+        "Psychology",
+        "Religious studies, Theology"
+      ],
+      "endDate": "2019-02-28",
+      "funder": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0105-organization-000"
+        }
+      ],
+      "grant": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0105-grant-000"
+        }
+      ],
+      "keywords": [
+        "Drawings",
+        "Child development",
+        "Cross-cultural",
+        "Database",
+        "Digital humanities",
+        "Supernatural agents",
+        "Interdisciplinarity"
+      ],
+      "name": "Drawings of gods: A Multicultural and Interdisciplinary Approach of Children’s Representations of Supernatural Agents",
+      "publication": [
+        "Vinck Dominique, Camus Alexandre, Jaton Florian, Oberhauser Pierre-Nicolas (2018), Localités distribuées, globalités localisées: actions, actants et médiations au service de l’ethnographie du numérique, in Symposium, 22(1), 41-60.",
+        "Brandt Pierre-Yves (2016), Représentations enfantines de dieux : comparaison interculturelle, in Rainotte Guy (ed.), Academia-L’Harmattan, Louvain-la-Neuve, 39-59.",
+        "Cocco Christelle, Ceré Raphaël, Xanthos Aris, Brandt Pierre-Yves (2019), Identification and quantification of colours in children’s drawings., in Proceedings of the Workshop on Computational Methods in the Humanities 2018, Lausanne http://ceur-ws.org/, Lausanne.",
+        "Oberhauser Pierre-Nicolas (2016), Des collaborations équivoques. La participation de spécialistes en sciences et techniques informatiques à un projet de recherche en humanités numériques, in Revue d'anthropologie des connaissances, 10(4), 557-586.",
+        "Brandt Pierre-Yves, Cocco Christelle, Dessart Grégory, Dandarova Robert Zhargalma, Représentations de dieux dans des dessins d’enfants, in Représenter dieux et hommes dans le Proche-Orient ancien, Collège de France, Paris.",
+        "Darbellay Frédéric, Vinck Dominique, Cocco Christelle, Dessart Grégory, Dandarova Robert Zhargalma, Brandt Pierre-Yves (2018), L'interdisciplinarité en partage: collaborer pour innover - Le projet \"dessins de dieu\", in InnovatiO, (5), NA.",
+        "Cocco Christelle, Dessart Grégory, Serbaeva Olga, Brandt Pierre-Yves, Vinck Dominique, Darbellay Frédéric (2018), Potentialités et difficultés d’un projet en humanités numériques (DH) : confrontation aux outils et réorientations de recherche, in Digital Humanities Quarterly, 12(1).",
+        "Dandarova Robert Zhargalma, Dessart Grégory, Serbaeva Olga, Puzdriac Camelia, Khodayarifard Mohammad, Akbari Zardkhaneh Saeed, Zandi Saeid, Petanova Elena, Ladd Kevin, Brandt Pierre-Yves (2016), A Web-based Database for Drawings of Gods: When the Digitals Go Multicultural, in Archive for the Psychology of Religion, (3), 345-352."
+      ],
+      "shortcode": "0105",
+      "spatialCoverage": [
+        {
+          "place": {
+            "name": "Geonames",
+            "url": "https://www.geonames.org/1861060/japan.html"
+          }
+        },
+        {
+          "place": {
+            "name": "Geonames",
+            "url": "https://www.geonames.org/2750405/kingdom-of-the-netherlands.html"
+          }
+        },
+        {
+          "place": {
+            "name": "Geonames",
+            "url": "https://www.geonames.org/2658434/switzerland.html"
+          }
+        },
+        {
+          "place": {
+            "name": "Geonames",
+            "url": "https://www.geonames.org/6252001/united-states.html"
+          }
+        },
+        {
+          "place": {
+            "name": "Geonames",
+            "url": "https://www.geonames.org/2017370/russian-federation.html"
+          }
+        },
+        {
+          "place": {
+            "name": "Geonames",
+            "url": "https://www.geonames.org/3469034/federative-republic-of-brazil.html"
+          }
+        },
+        {
+          "place": {
+            "name": "Geonames",
+            "url": "https://www.geonames.org/3865483/argentine-republic.html"
+          }
+        },
+        {
+          "place": {
+            "name": "Geonames",
+            "url": "https://www.geonames.org/798549/romania.html"
+          }
+        },
+        {
+          "place": {
+            "name": "Geonames",
+            "url": "https://www.geonames.org/130758/islamic-republic-of-iran.html"
+          }
+        },
+        {
+          "place": {
+            "name": "Geonames",
+            "url": "https://www.geonames.org/1282988/nepal.html"
+          }
+        }
+      ],
+      "startDate": "2015-03-01",
+      "temporalCoverage": [
+        "1987-2018"
+      ],
+      "url": [
+        {
+          "name": "dasch.swiss",
+          "type": "https://schema.org/URL",
+          "url": "http://ark.dasch.swiss/ark:/72163/1/0105"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Organization",
+      "id": "http://ns.dasch.swiss/repository#dsp-0105-organization-002",
+      "address": {
+        "type": "https://schema.org/PostalAddress",
+        "addressLocality": "Genève 4",
+        "postalCode": "1211",
+        "streetAddress": "24 rue du Général-Dufour"
+      },
+      "name": [
+        "Université de Genève"
+      ],
+      "url": [
+        {
+          "name": "unige.ch",
+          "type": "https://schema.org/URL",
+          "url": "https://www.unige.ch/"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0105-person-000",
+      "email": [
+        "pierre-yves.Brandt@unil.ch"
+      ],
+      "familyName": "Brandt",
+      "givenName": "Pierre-Yves",
+      "jobTitle": [
+        "Full professor"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0105-organization-001"
+        }
+      ],
+      "sameAs": [
+        {
+          "name": "ORCID",
+          "type": "https://schema.org/URL",
+          "url": "https://orcid.org/0000-0002-4485-5807"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0105-person-008",
+      "email": [
+        "marion.rivoal@unil.ch"
+      ],
+      "familyName": "Rivoal",
+      "givenName": "Marion",
+      "jobTitle": [
+        "Research manager"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0105-organization-001"
+        }
+      ],
+      "sameAs": [
+        {
+          "name": "ORCID",
+          "type": "https://schema.org/URL",
+          "url": "https://orcid.org/0000-0003-4185-7169"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0105-person-007",
+      "email": [
+        "loic.jaouen@unil.ch"
+      ],
+      "familyName": "Jaouen",
+      "givenName": "Loïc",
+      "jobTitle": [
+        "IT support"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0105-organization-001"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0105-person-009",
+      "familyName": "Laubscher",
+      "givenName": "Karine",
+      "jobTitle": [
+        "Psychologist"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0105-organization-001"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0105-person-005",
+      "email": [
+        "christelle.cocco@unil.ch"
+      ],
+      "familyName": "Cocco",
+      "givenName": "Christelle",
+      "jobTitle": [
+        "Post-doctoral researcher",
+        "Senior SNSF researcher"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0105-organization-001"
+        }
+      ],
+      "sameAs": [
+        {
+          "name": "ORCID",
+          "type": "https://schema.org/URL",
+          "url": "https://orcid.org/0000-0001-6684-9806"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0105-person-006",
+      "email": [
+        "gregory.dessart@unil.ch"
+      ],
+      "familyName": "Dessart",
+      "givenName": "Grégory",
+      "jobTitle": [
+        "PhD student"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0105-organization-001"
+        }
+      ],
+      "sameAs": [
+        {
+          "name": "ORCID",
+          "type": "https://schema.org/URL",
+          "url": "https://orcid.org/0000-0003-1986-9702"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0105-person-003",
+      "email": [
+        "frederic.darbellay@unige.ch"
+      ],
+      "familyName": "Darbellay",
+      "givenName": "Frédéric",
+      "jobTitle": [
+        "Associate professor"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0105-organization-002"
+        }
+      ],
+      "sameAs": [
+        {
+          "name": "ORCID",
+          "type": "https://schema.org/URL",
+          "url": "https://orcid.org/0000-0003-1321-7105"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Grant",
+      "id": "http://ns.dasch.swiss/repository#dsp-0105-grant-000",
+      "funder": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0105-organization-000"
+        }
+      ],
+      "name": "Interdisciplinary projects ",
+      "number": "156383",
+      "url": [
+        {
+          "name": "snf.ch",
+          "type": "https://schema.org/URL",
+          "url": "http://p3.snf.ch/Project-156383"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0105-person-004",
+      "email": [
+        "olga.serbaeva@aoi.uzh.ch",
+        "olga.serbaeva@unil.ch"
+      ],
+      "familyName": "Serbaeva Saraogi",
+      "givenName": "Olga",
+      "jobTitle": [
+        "Developer"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0105-organization-001"
+        }
+      ]
+    }
+  ]
+}

--- a/services/metadata/backend/fake-backend/data/geoarch-metadata.json
+++ b/services/metadata/backend/fake-backend/data/geoarch-metadata.json
@@ -1,0 +1,160 @@
+{
+  "projectsMetadata": [
+    {
+      "type": "http://ns.dasch.swiss/repository#Dataset",
+      "id": "http://ns.dasch.swiss/repository#dsp-0838-dataset-001",
+      "abstract": [
+        "D: Die geoarchäologische Sammlung am IPNA (Integrative Prähistorische und Naturwissenschaftliche Archäologie) der Universität Basel umfasst u.a. Block- und Sedimentproben von natürlichen Böden sowie archäologischen Schichten, ferner auch Gesteinen, Silices, Keramik etc. Diese Sammlung kann dank der „I-GEOARCHive“ Bilddatenbank in Form von Fotografien und Dünnschliffscans (mit entsprechenden Mikroskopfotos) einer breiten Öffentlichkeit und insbesondere der Forschung und Lehre zugänglich gemacht werden. Die frei zugängliche „I-GEOARCHive“ ermöglicht den Nutzer*innen das Beschlagworten, Analysieren, Publizieren und Archivieren geoarchäologischer Proben. Darüber hinaus sind mikromorphologische Befunde mit den Dünnschliffscans und dadurch mit den Blockproben und Profilen verknüpft. Durch diese Vernetzung wird eine multidimensionale Publikation und Archivierung mikromorphologischer Bilddaten und ihr Bezug zum originalen Feldbefund möglich.",
+        "E: The geoarchaeological collection of the IPAS (Integrative Prehistory and Archaeological Science) at the University of Basel includes block and sediment samples of soils and archaeological deposits as well as rocks, flints, ceramics etc. The „I-GEOARCHive“ image database of thin section scans (and corresponding microscope photos) makes the collection digitally accessible to the public and in particular to research and teaching. The freely accessible „I-GEOARCHive“ database enables users to keyword, analyse, publish and archive geoarchaeological samples. Furthermore, micromorphological observations are linked to the thin section scans and thus to the block samples and profiles. This cross-linking enables multidimensional publication and archiving of micromorphological image data and their relation to original archaeological features. "
+      ],
+      "conditionsOfAccess": "Open Access",
+      "dateModified": "2021-01-01",
+      "datePublished": "2021-01-01",
+      "howToCite": "https://geoarchI-GEOARCHive.dasch.swiss",
+      "language": [
+        "Englisch",
+        "Deutsch"
+      ],
+      "license": [
+        {
+          "name": "creativecommons.org",
+          "type": "https://schema.org/URL",
+          "url": "https://creativecommons.org/licenses/by-nc-sa/3.0/"
+        }
+      ],
+      "qualifiedAttribution": [
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Researcher"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0838-person-001"
+            }
+          ]
+        }
+      ],
+      "status": "Ongoing",
+      "title": "I-GEOARCHive",
+      "typeOfData": [
+        "Image",
+        "Text"
+      ],
+      "project": {
+        "id": "http://ns.dasch.swiss/repository#dsp-0838-project"
+      }
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Project",
+      "id": "http://ns.dasch.swiss/repository#dsp-0838-project",
+      "alternateName": [
+        "geoarch",
+        " I-GEOARCHive "
+      ],
+      "contactPoint": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0838-person-001"
+        }
+      ],
+      "description": "D: Die geoarchäologische Sammlung am IPNA (Integrative Prähistorische und Naturwissenschaftliche Archäologie) der Universität Basel umfasst u.a. Block- und Sedimentproben von natürlichen Böden sowie archäologischen Schichten, ferner auch Gesteinen, Silices, Keramik etc. Diese Sammlung kann dank der „I-GEOARCHive“ Bilddatenbank in Form von Fotografien und Dünnschliffscans (mit entsprechenden Mikroskopfotos) einer breiten Öffentlichkeit und insbesondere der Forschung und Lehre zugänglich gemacht werden. Die frei zugängliche „I-GEOARCHive“ ermöglicht den Nutzer*innen das Beschlagworten, Analysieren, Publizieren und Archivieren geoarchäologischer Proben. Darüber hinaus sind mikromorphologische Befunde mit den Dünnschliffscans und dadurch mit den Blockproben und Profilen verknüpft. Durch diese Vernetzung wird eine multidimensionale Publikation und Archivierung mikromorphologischer Bilddaten und ihr Bezug zum originalen Feldbefund möglich.\n\nE: The geoarchaeological collection of the IPAS (Integrative Prehistory and Archaeological Science) at the University of Basel includes block and sediment samples of soils and archaeological deposits as well as rocks, flints, ceramics etc. The „I-GEOARCHive“ image database of thin section scans (and corresponding microscope photos) makes the collection digitally accessible to the public and in particular to research and teaching. The freely accessible „I-GEOARCHive“ database enables users to keyword, analyse, publish and archive geoarchaeological samples. Furthermore, micromorphological observations are linked to the thin section scans and thus to the block samples and profiles. This cross-linking enables multidimensional publication and archiving of micromorphological image data and their relation to original archaeological features. \n\n",
+      "discipline": [
+        {
+          "name": "SKOS UNESCO Nomenclature",
+          "type": "https://schema.org/URL",
+          "url": "https://skos.um.es/unesco6/2506/html"
+        }
+      ],
+      "endDate": "2021-12-31",
+      "funder": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0838-organization-001"
+        }
+      ],
+      "grant": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0838-grant-001"
+        }
+      ],
+      "keywords": [
+        "anthropogenic material",
+        "Geologie",
+        "Petrography",
+        "Geoarchäologie",
+        "anthropogene Materialien",
+        "Thin Section",
+        "Mikromorphologie",
+        "Dünnschliff",
+        "archäologische Schicht",
+        "Micromorphology",
+        "archaeological deposit",
+        "Geoarchaeology",
+        "Microphoto",
+        "Geology",
+        "Mikrofoto",
+        "Petrographie"
+      ],
+      "name": "Bilddatenbank Geoarchäologie ",
+      "shortcode": "0838",
+      "spatialCoverage": [
+        {
+          "place": {
+            "name": "Geonames",
+            "url": "https://www.geonames.org/2658434/switzerland.html"
+          }
+        },
+        {
+          "place": {
+            "name": "Geonames",
+            "url": "https://www.geonames.org/2802361/kingdom-of-belgium.html"
+          }
+        }
+      ],
+      "startDate": "1900-01-01",
+      "temporalCoverage": [
+        {
+          "name": "dainst.org",
+          "type": "https://schema.org/URL",
+          "url": "http://chronontology.dainst.org/period/JMHQs1UHRe3a"
+        }
+      ],
+      "url": [
+        {
+          "name": "dasch.swiss",
+          "type": "https://schema.org/URL",
+          "url": "http://ark.dasch.swiss/ark:/72163/1/0838"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Grant",
+      "id": "http://ns.dasch.swiss/repository#dsp-0838-grant-001",
+      "funder": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0838-organization-001"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0838-person-001",
+      "familyName": "Butterfly",
+      "givenName": "John",
+      "jobTitle": [
+        "Postdoc"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0838-organization-001"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Organization",
+      "id": "http://ns.dasch.swiss/repository#dsp-0838-organization-001",
+      "name": [
+        "Departement für Umweltwissenschaften der Universität Basel"
+      ]
+    }
+  ]
+}

--- a/services/metadata/backend/fake-backend/data/hdm-metadata.json
+++ b/services/metadata/backend/fake-backend/data/hdm-metadata.json
@@ -1,0 +1,130 @@
+{
+    "projectsMetadata": [
+        {
+            "type": "http://ns.dasch.swiss/repository#Dataset",
+            "id": "http://ns.dasch.swiss/repository#dsp-081C-dataset-000",
+            "abstract": [
+                "The database documents the events that took place in the Hôtel de Musique in Bern between 1766 and 1905. The repertoire was constituted by different kinds of spectacles like theatre plays, operas, ballets, concerts, dance parties, acrobatic performances, conferences or magicians. The list reconstructs the lifely and colourful theatre culture of Bern in the 19th Century."
+            ],
+            "conditionsOfAccess": "open",
+            "datePublished": "2015-04-01",
+            "howToCite": "HdM-Bern",
+            "language": [
+                "German"
+            ],
+            "license": [
+                {
+                    "name": "Creative Commons",
+                    "type": "https://schema.org/URL",
+                    "url": "https://creativecommons.org/licenses/by-nc/4.0"
+                }
+            ],
+            "qualifiedAttribution": [
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "author"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-081C-organization-000"
+                        }
+                    ]
+                }
+            ],
+            "status": "Finished",
+            "title": "Hôtel de Musique Bern",
+            "typeOfData": [
+                "Text"
+            ],
+            "project": {
+                "id": "http://ns.dasch.swiss/repository#dsp-081C-project"
+            }
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Project",
+            "id": "http://ns.dasch.swiss/repository#dsp-081C-project",
+            "description": "The database documents the events that took place in the Hôtel de Musique in Bern between 1766 and 1905. The repertoire was constituted by different kinds of spectacles like theatre plays, operas, ballets, concerts, dance parties, acrobatic performances, conferences or magicians. The list reconstructs the lifely and colourful theatre culture of Bern in the 19th Century.",
+            "discipline": [
+                "10604 Musik und Theater",
+                "10406 Theater-und Filmwissenschaften",
+                "10405 Musikologie",
+                "10302 Schweizer Geschichte"
+            ],
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-081C-organization-000"
+                }
+            ],
+            "keywords": [
+                "Concert",
+                "Switzerland",
+                "Theater history",
+                "Musicology",
+                "Music",
+                "Opera",
+                "Theatre",
+                "Bern",
+                "19 Century",
+                "Spectales"
+            ],
+            "name": "Hôtel de Musique Bern",
+            "shortcode": "081C",
+            "spatialCoverage": [
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/2661552"
+                    }
+                }
+            ],
+            "startDate": "2009-04-01",
+            "temporalCoverage": [
+                {
+                    "name": "Periodo",
+                    "type": "https://schema.org/URL",
+                    "url": "http://n2t.net/ark:/99152/p06c6g3pvr5"
+                },
+                "1766-1905",
+                {
+                    "name": "Periodo",
+                    "type": "https://schema.org/URL",
+                    "url": "http://n2t.net/ark:/99152/p06c6g3p4cf"
+                },
+                {
+                    "name": "Periodo",
+                    "type": "https://schema.org/URL",
+                    "url": "http://n2t.net/ark:/99152/p06c6g364np"
+                }
+            ],
+            "url": [
+                {
+                    "name": "www.salsah.o",
+                    "type": "https://schema.org/URL",
+                    "url": "www.salsah.org"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-081C-organization-000",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Bern",
+                "postalCode": "3011",
+                "streetAddress": "Mittelstr. 43"
+            },
+            "email": "urchueguia@musik.unibe.ch",
+            "name": [
+                "Institut für Musikwissenschaft der Universität Bern"
+            ],
+            "url": [
+                {
+                    "name": "musik.unibe.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "https://www.musik.unibe.ch/index_ger.html"
+                }
+            ]
+        }
+    ]
+}

--- a/services/metadata/backend/fake-backend/data/limc-metadata.json
+++ b/services/metadata/backend/fake-backend/data/limc-metadata.json
@@ -1,0 +1,348 @@
+{
+    "projectsMetadata": [
+        {
+            "type": "http://ns.dasch.swiss/repository#Dataset",
+            "id": "http://ns.dasch.swiss/repository#dsp-080E-dataset-000",
+            "abstract": [
+                "Digital LIMC makes accessible what we know about the iconography of Greek, Etruscan and Roman mythology in ancient Greek, Etruscan and Roman art as well as in the one of the neighbouring civilisations of the Mediterranean, to all people interested in classical antiquity. It contains basic information about more than 55’000 archaeological objects (e.g. vases, sculpture, gems, mosaics) which were assembled in the course of the preparation of the printed books of the LIMC and the ThesCRA from about 1970 onward. Short keyword type object descriptions and links to other research projects or museum databases will be added continuously as far as funds permit. The images of the objects are accessible online if the owning institution has given us permission for diffusion."
+            ],
+            "alternativeTitle": "Digital LIMC",
+            "conditionsOfAccess": "open",
+            "dateCreated": "2014-06-02",
+            "datePublished": "2016-12-20",
+            "howToCite": "Digital LIMC (2021): Digital LIMC, DaSCH. https://weblimc.org/page/home/Basel",
+            "language": [
+                "Greek",
+                "English",
+                "Italian",
+                "French",
+                "German"
+            ],
+            "license": [
+                {
+                    "name": "Creative Commons",
+                    "type": "https://schema.org/URL",
+                    "url": "https://creativecommons.org/licenses/by-nc/4.0/"
+                }
+            ],
+            "qualifiedAttribution": [
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "publisher"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-080E-organization-005"
+                        }
+                    ]
+                }
+            ],
+            "status": "Ongoing",
+            "title": "Dataset of Digital Lexicon Iconographicum Mythologiae Classicae (Digital LIMC)",
+            "typeOfData": [
+                "Image",
+                "Text"
+            ],
+            "project": {
+                "id": "http://ns.dasch.swiss/repository#dsp-080E-project"
+            }
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-080E-organization-003",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Basel",
+                "postalCode": "4002",
+                "streetAddress": "St. Jakobs-Strasse 7, Postfach 2879"
+            },
+            "name": [
+                "Ceramica Stiftung"
+            ],
+            "url": [
+                {
+                    "name": "ceramica-ch.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "https://ceramica-ch.ch/"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-080E-organization-004",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Basel",
+                "postalCode": "4020",
+                "streetAddress": "Rennweg 50"
+            },
+            "email": "contact@binding-stiftung.ch\r\r ",
+            "name": [
+                "Sophie und Karl Binding Stiftung"
+            ],
+            "url": [
+                {
+                    "name": "binding-stiftung.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "https://www.binding-stiftung.ch/"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Grant",
+            "id": "http://ns.dasch.swiss/repository#dsp-080E-grant-004",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-080E-organization-004"
+                }
+            ],
+            "name": "Gesuch im Bereich Kultur",
+            "number": "19-109"
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Project",
+            "id": "http://ns.dasch.swiss/repository#dsp-080E-project",
+            "alternateName": [
+                "Digital LIMC"
+            ],
+            "description": "Digital LIMC is a digital platform for Classical Mythology, it contains what we know about the iconography of Greek, Etruscan and Roman mythology, both in ancient Greek, Etruscan and Roman art as well as in the one of neighbouring Mediterranean cultures. These literary and iconographical sources of ancient mythology are key elements of the cultural heritage of mankind. The Foundation for the LIMC prepared and published 10 volumes of the Lexicon Iconographicum Mythologiae Classicae (LIMC) between 1981 and 2009. This publication project was followed by the Thesaurus Cultus et Rituum Antiquorum (ThesCRA; 10 volumes), focussing on ritual and cult in antiquity.\n\nDigital LIMC makes all data accessible which were assembled in the course of the preparation of the printed books and which are stored in the basement of a building of the University of Basel today. \n\n",
+            "discipline": [
+                {
+                    "name": "SKOS UNESCO Nomenclature",
+                    "type": "https://schema.org/URL",
+                    "url": "http://skos.um.es/unesco6/550501"
+                }
+            ],
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-080E-organization-004"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-080E-organization-000"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-080E-organization-002"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-080E-organization-001"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-080E-organization-003"
+                }
+            ],
+            "grant": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-080E-grant-002"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-080E-grant-004"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-080E-grant-003"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-080E-grant-000"
+                },
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-080E-grant-001"
+                }
+            ],
+            "keywords": [
+                "Roman",
+                "Near East",
+                "Egypt",
+                "Greece",
+                "Mythology",
+                "Archaeology",
+                "Etruria"
+            ],
+            "name": "Digital Lexicon Iconographicum Mythologiae Classicae (Digital LIMC)",
+            "shortcode": "080E",
+            "spatialCoverage": [
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/6255147"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/6255148"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/7729887"
+                    }
+                }
+            ],
+            "startDate": "2014-06-02",
+            "temporalCoverage": [
+                {
+                    "name": "ChronOntology",
+                    "type": "https://schema.org/URL",
+                    "url": "http://chronontology.dainst.org/period/YOyP9TLDuhrb"
+                },
+                {
+                    "name": "ChronOntology",
+                    "type": "https://schema.org/URL",
+                    "url": "http://chronontology.dainst.org/period/RGbECa9kHJT4"
+                },
+                {
+                    "name": "ChronOntology",
+                    "type": "https://schema.org/URL",
+                    "url": "http://chronontology.dainst.org/period/6VooUMYGJjOI"
+                },
+                {
+                    "name": "ChronOntology",
+                    "type": "https://schema.org/URL",
+                    "url": "http://chronontology.dainst.org/period/yY1zReDz86zF"
+                },
+                {
+                    "name": "ChronOntology",
+                    "type": "https://schema.org/URL",
+                    "url": "http://chronontology.dainst.org/period/3mQhHXhO86oj"
+                }
+            ],
+            "url": [
+                {
+                    "name": "weblimc.org",
+                    "type": "https://schema.org/URL",
+                    "url": "https://weblimc.org/page/home/Basel"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-080E-organization-001",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Monte Carlo, Monaco",
+                "postalCode": "98000",
+                "streetAddress": "14 Avenue de Grande Bretagne \"Le George V\" 4eme étage"
+            },
+            "email": "info@snf.org",
+            "name": [
+                "Stavros Niarchos Foundation"
+            ],
+            "url": [
+                {
+                    "name": "snf.org",
+                    "type": "https://schema.org/URL",
+                    "url": "https://www.snf.org/en"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-080E-organization-002",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Zug",
+                "postalCode": "6300",
+                "streetAddress": "Artherstrasse 19"
+            },
+            "name": [
+                "Ernst Göhner Stiftung"
+            ],
+            "url": [
+                {
+                    "name": "ernst-goehner-stiftung.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "http://www.ernst-goehner-stiftung.ch/index.php/de"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Grant",
+            "id": "http://ns.dasch.swiss/repository#dsp-080E-grant-000",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-080E-organization-000"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-080E-organization-000",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Bern",
+                "postalCode": "3001",
+                "streetAddress": "Effingerstrasse 15, Postfach"
+            },
+            "name": [
+                "swissuniversities"
+            ],
+            "url": [
+                {
+                    "name": "swissuniversities.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "https://www.swissuniversities.ch/"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Grant",
+            "id": "http://ns.dasch.swiss/repository#dsp-080E-grant-003",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-080E-organization-003"
+                }
+            ],
+            "number": "14/17-18"
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Grant",
+            "id": "http://ns.dasch.swiss/repository#dsp-080E-grant-001",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-080E-organization-001"
+                }
+            ],
+            "name": "Program Support Education",
+            "url": [
+                {
+                    "name": "snf.org",
+                    "type": "https://schema.org/URL",
+                    "url": "https://www.snf.org/en/grants/grantees/u/university-of-basel/department-of-ancient-civilisations-program-support/"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-080E-organization-005",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Basel",
+                "postalCode": "4051",
+                "streetAddress": "Petersgraben 51"
+            },
+            "email": "martin-a.guggisberg@unibas.ch",
+            "name": [
+                "Classical Archaeology, University of Basel"
+            ],
+            "url": [
+                {
+                    "name": "philhist.unibas.ch",
+                    "type": "https://schema.org/URL",
+                    "url": "https://klassarch.philhist.unibas.ch/de/home/"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Grant",
+            "id": "http://ns.dasch.swiss/repository#dsp-080E-grant-002",
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-080E-organization-002"
+                }
+            ],
+            "name": "Gesuch im Bereich Bildung und Wissenschaft",
+            "number": "2015-2371/1.2"
+        }
+    ]
+}

--- a/services/metadata/backend/fake-backend/data/rosetta-metadata.json
+++ b/services/metadata/backend/fake-backend/data/rosetta-metadata.json
@@ -1,0 +1,150 @@
+{
+    "projectsMetadata": [
+        {
+            "type": "http://ns.dasch.swiss/repository#Dataset",
+            "id": "http://ns.dasch.swiss/repository#dsp-082E-dataset-000",
+            "abstract": [
+                "Rosetta is the sample project of DaSCH. It contains texts, objects, documents and images from different cultures and times. In the future the sample project will be enriched with new types of data such as audio, video and 3D-images. The downloadable file rosetta.zip contains the data model (json-file), the data itself (xml.file) as well as some documentation (pdf and csv-files). You can use these files to start creating your own data model."
+            ],
+            "conditionsOfAccess": "open",
+            "documentation": [
+                "Added as zip-file to project (rosetta.zip)"
+            ],
+            "howToCite": "DaSCH (2021): Rosetta, DaSCH. http://ark.dasch.swiss/ark:/72163/1/082E/",
+            "language": [
+                "Akkadian",
+                "Englisch",
+                "Greek",
+                "Russian",
+                "Egyptian",
+                "French",
+                "German",
+                "Arabic",
+                "Hebrew"
+            ],
+            "license": [
+                {
+                    "name": "Creative Commons",
+                    "type": "https://schema.org/URL",
+                    "url": "https://creativecommons.org/licenses/by/4.0"
+                }
+            ],
+            "qualifiedAttribution": [
+                {
+                    "type": "http://www.w3.org/ns/prov#Attribution",
+                    "role": [
+                        "creator"
+                    ],
+                    "agent": [
+                        {
+                            "id": "http://ns.dasch.swiss/repository#dsp-082E-organization-000"
+                        }
+                    ]
+                }
+            ],
+            "status": "Ongoing",
+            "title": "Rosetta",
+            "typeOfData": [
+                "Image",
+                "Audio",
+                "Text",
+                "Movie",
+                "XML"
+            ],
+            "project": {
+                "id": "http://ns.dasch.swiss/repository#dsp-082E-project"
+            }
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Project",
+            "id": "http://ns.dasch.swiss/repository#dsp-082E-project",
+            "contactPoint": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082E-organization-000"
+                }
+            ],
+            "description": "Rosetta is the sample project of DaSCH. It contains texts, objects, documents and images from different cultures and times. In the future the sample project will be enriched with new types of data such as audio, video and 3D-images. The downloadable file rosetta.zip contains the data model (json-file), the data itself (xml.file) as well as some documentation (pdf and csv-files). You can use these files to start creating your own data model.",
+            "discipline": [
+                {
+                    "name": "SKOS UNESCO Nomenclature",
+                    "type": "https://schema.org/URL",
+                    "url": "http://skos.um.es/unesco6/550501"
+                },
+                {
+                    "name": "SKOS UNESCO Nomenclature",
+                    "type": "https://schema.org/URL",
+                    "url": "http://skos.um.es/unesco6/620303"
+                },
+                {
+                    "name": "SKOS UNESCO Nomenclature",
+                    "type": "https://schema.org/URL",
+                    "url": "http://skos.um.es/unesco6/570107"
+                }
+            ],
+            "funder": [
+                {
+                    "id": "http://ns.dasch.swiss/repository#dsp-082E-organization-000"
+                }
+            ],
+            "keywords": [
+                "archaeology",
+                "literature",
+                "art"
+            ],
+            "name": "Rosetta",
+            "shortcode": "082E",
+            "spatialCoverage": [
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/6255147"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/6255146"
+                    }
+                },
+                {
+                    "place": {
+                        "name": "Geonames",
+                        "url": "https://www.geonames.org/6255148"
+                    }
+                }
+            ],
+            "startDate": "2020-12-21",
+            "temporalCoverage": [
+                "3rd millennium BCE to modern time"
+            ],
+            "url": [
+                {
+                    "name": "app.test.das",
+                    "type": "https://schema.org/URL",
+                    "url": "app.test.dasch.swiss"
+                }
+            ]
+        },
+        {
+            "type": "http://ns.dasch.swiss/repository#Organization",
+            "id": "http://ns.dasch.swiss/repository#dsp-082E-organization-000",
+            "address": {
+                "type": "https://schema.org/PostalAddress",
+                "addressLocality": "Allschwil",
+                "postalCode": "4123",
+                "streetAddress": "Gewerbestrasse 24"
+            },
+            "email": "info@dasch.swiss",
+            "name": [
+                "Data and Service Center for the Humanities DaSCH"
+            ],
+            "url": [
+                {
+                    "name": "www.dasch.sw",
+                    "type": "https://schema.org/URL",
+                    "url": "www.dasch.swiss"
+                }
+            ]
+        }
+    ]
+}

--- a/services/metadata/backend/fake-backend/data/sumer-metadata.json
+++ b/services/metadata/backend/fake-backend/data/sumer-metadata.json
@@ -1,0 +1,308 @@
+{
+  "projectsMetadata": [
+    {
+      "type": "http://ns.dasch.swiss/repository#Dataset",
+      "id": "http://ns.dasch.swiss/repository#dsp-0824-dataset-001",
+      "abstract": [
+        "F: La base de données comporte environ 55'000 entrées enregistrant la littérature secondaire consacrée à un lexème sumérien. Chaque entrée est constituée d'une séquence de signes principale et de leurs lectures possibles, avec le plus souvent renvoi aux graphies non-standards. Pour chaque lexème, la littérature secondaire est saisie, avec pas rarement indication des significations proposées. ",
+        "E: The database comprises about 55'000 entries listing the secondary literature on Sumerian lexemes. Each entry consists of a main sign sequence with its possible readings and includes references to unorthographical writings. Each lexeme is provided with a list of secondary literature, often indicating the meanings suggested therein.",
+        "D: Die Datenbank umfasst etwa 55'000 Einträge mit Sekundärliteratur zu sumerischen Lexemen. Jeder Eintrag basiert auf einer Hauptzeichenabfolge mit möglichen Lesungen und unorthografischen Schreibungen. Für jedes Lexem wird die Sekundärliteratur erfasst und nicht selten werden die in den Beiträgen vorgeschlagenen Bedeutungen wiedergegeben. "
+      ],
+      "conditionsOfAccess": "Open Access",
+      "datePublished": "2022-01-01",
+      "howToCite": "https://dssl.dasch.swiss",
+      "language": [
+        "Englisch",
+        "Deutsch",
+        "Sumerisch",
+        "Französisch",
+        "Akkadisch"
+      ],
+      "license": [
+        {
+          "name": "creativecommons.org",
+          "type": "https://schema.org/URL",
+          "url": "https://creativecommons.org/licenses/by-nc-nd/4.0/"
+        }
+      ],
+      "qualifiedAttribution": [
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Contributor"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0824-person-003"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Contributor"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0824-person-005"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Contributor"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0824-person-002"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Contributor"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0824-person-004"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Contributor"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0824-person-001"
+            }
+          ]
+        }
+      ],
+      "status": "Ongoing",
+      "title": "Dataset of Datenbank der sumerischen Sekundärliteratur",
+      "typeOfData": [
+        "Text"
+      ],
+      "project": {
+        "id": "http://ns.dasch.swiss/repository#dsp-0824-project"
+      }
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Organization",
+      "id": "http://ns.dasch.swiss/repository#dsp-0824-organization-003",
+      "name": [
+        "Université de Genève"
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Organization",
+      "id": "http://ns.dasch.swiss/repository#dsp-0824-organization-001",
+      "name": [
+        "Schweizerische Akademie der Geisteswissenschaften (SAGW) "
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0824-person-003",
+      "familyName": "Ecklin",
+      "givenName": "Sabine",
+      "jobTitle": [
+        "Researcher"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0824-organization-003"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Project",
+      "id": "http://ns.dasch.swiss/repository#dsp-0824-project",
+      "alternateName": [
+        "SumSekLit",
+        "DSSL"
+      ],
+      "description": "D: Die Datenbank umfasst etwa 55'000 Einträge mit Sekundärliteratur zu sumerischen Lexemen. Jeder Eintrag basiert auf einer Hauptzeichenabfolge mit möglichen Lesungen und unorthografischen Schreibungen. Für jedes Lexem wird die Sekundärliteratur erfasst und nicht selten werden die in den Beiträgen vorgeschlagenen Bedeutungen wiedergegeben. \nF: La base de données comporte environ 55'000 entrées enregistrant la littérature secondaire consacrée à un lexème sumérien. Chaque entrée est constituée d'une séquence de signes principale et de leurs lectures possibles, avec le plus souvent renvoi aux graphies non-standards. Pour chaque lexème, la littérature secondaire est saisie, avec pas rarement indication des significations proposées. \n\nE: The database comprises about 55'000 entries listing the secondary literature on Sumerian lexemes. Each entry consists of a main sign sequence with its possible readings and includes references to unorthographical writings. Each lexeme is provided with a list of secondary literature, often indicating the meanings suggested therein.",
+      "discipline": [
+        {
+          "name": "SKOS UNESCO Nomenclature",
+          "type": "https://schema.org/URL",
+          "url": "https://skos.um.es/unesco6/550510/html"
+        }
+      ],
+      "endDate": "2022-01-01",
+      "funder": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0824-organization-002"
+        },
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0824-organization-001"
+        }
+      ],
+      "grant": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0824-grant-002"
+        }
+      ],
+      "keywords": [
+        "Altorientalistik",
+        "Sekundärliteratur",
+        "Akkadian",
+        "secondary literature",
+        "littérature secondaire",
+        "Assyriology",
+        "Sumérien",
+        "Sumerisch",
+        "Mesopotamia",
+        "cuneiform",
+        "Mésopotamie",
+        "Mesopotamien",
+        "Akkadisch",
+        "Keilschrift",
+        "akkadien",
+        "Sumerian",
+        "cunéiforme",
+        "Assyriologie"
+      ],
+      "name": "Datenbank der sumerischen Sekundärliteratur",
+      "shortcode": "0824",
+      "spatialCoverage": [
+        {
+          "place": {
+            "name": "Geonames",
+            "url": "https://www.geonames.org/6255147/asia.html"
+          }
+        },
+        {
+          "place": {
+            "name": "Geonames",
+            "url": "https://www.geonames.org/298795/republic-of-turkey.html"
+          }
+        },
+        {
+          "place": {
+            "name": "Geonames",
+            "url": "https://www.geonames.org/99237/republic-of-iraq.html"
+          }
+        },
+        {
+          "place": {
+            "name": "Geonames",
+            "url": "https://www.geonames.org/130758/islamic-republic-of-iran.html"
+          }
+        },
+        {
+          "place": {
+            "name": "Geonames",
+            "url": "https://www.geonames.org/163843/syrian-arab-republic.html"
+          }
+        }
+      ],
+      "startDate": "2014-10-01",
+      "temporalCoverage": [
+        {
+          "name": "dainst.org",
+          "type": "https://schema.org/URL",
+          "url": "http://chronontology.dainst.org/period/ZAxRV9WoxlrI"
+        }
+      ],
+      "url": [
+        {
+          "name": "dasch.swiss",
+          "type": "https://schema.org/URL",
+          "url": "https://dssl.dasch.swiss"
+        },
+        {
+          "name": "dasch.swiss",
+          "type": "https://schema.org/URL",
+          "url": "http://ark.dasch.swiss/ark:/72163/1/0824"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Organization",
+      "id": "http://ns.dasch.swiss/repository#dsp-0824-organization-002",
+      "name": [
+        "Schweizerischer Nationalfonds (SNSF) "
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0824-person-005",
+      "familyName": "Novák",
+      "givenName": "Mirko",
+      "jobTitle": [
+        "Researcher"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0824-organization-003"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Grant",
+      "id": "http://ns.dasch.swiss/repository#dsp-0824-grant-001",
+      "funder": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0824-organization-001"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0824-person-001",
+      "familyName": "Attinger",
+      "givenName": "Pascal",
+      "jobTitle": [
+        "Researcher"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0824-organization-003"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0824-person-004",
+      "familyName": "Mittermayer",
+      "givenName": "Catherine",
+      "jobTitle": [
+        "Researcher"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0824-organization-003"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Grant",
+      "id": "http://ns.dasch.swiss/repository#dsp-0824-grant-002",
+      "funder": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0824-organization-002"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0824-person-002",
+      "familyName": "Deubelbeiss",
+      "givenName": "Irene",
+      "jobTitle": [
+        "Researcher"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0824-organization-003"
+        }
+      ]
+    }
+  ]
+}

--- a/services/metadata/backend/fake-backend/data/wordweb-metadata.json
+++ b/services/metadata/backend/fake-backend/data/wordweb-metadata.json
@@ -1,0 +1,273 @@
+{
+  "projectsMetadata": [
+    {
+      "type": "http://ns.dasch.swiss/repository#Dataset",
+      "id": "http://ns.dasch.swiss/repository#dsp-0826-dataset-000",
+      "abstract": [
+        "4500 extracts from plays and other texts written no later than 1688, mostly in English"
+      ],
+      "alternativeTitle": "WordWeb / IDEM",
+      "conditionsOfAccess": "Open",
+      "dateCreated": "2021-01-25",
+      "howToCite": "WordWeb/IDEM (2021), DaSCH. ark.dasch.swiss/ark:/72163/1/0826",
+      "language": [
+        "Portuguese",
+        "Latin",
+        "English",
+        "Spanish",
+        "Italian",
+        "Classical Greek",
+        "French",
+        "German"
+      ],
+      "license": [
+        {
+          "name": "Creative Commons",
+          "type": "https://schema.org/URL",
+          "url": "https://creativecommons.org/licenses/by-nc-nd/4.0/"
+        }
+      ],
+      "qualifiedAttribution": [
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Editor"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0826-person-001"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Author"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0826-person-001"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Editor"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0826-person-002"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Editor"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0826-person-003"
+            }
+          ]
+        },
+        {
+          "type": "http://www.w3.org/ns/prov#Attribution",
+          "role": [
+            "Creator"
+          ],
+          "agent": [
+            {
+              "id": "http://ns.dasch.swiss/repository#dsp-0826-person-001"
+            }
+          ]
+        }
+      ],
+      "status": "Ongoing",
+      "title": "WordWeb / IDEM: A new way of representing Intertextuality in Drama of the Early Modern Period",
+      "typeOfData": [
+        "Text"
+      ],
+      "project": {
+        "id": "http://ns.dasch.swiss/repository#dsp-0826-project"
+      }
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Organization",
+      "id": "http://ns.dasch.swiss/repository#dsp-0826-organization-001",
+      "name": [
+        "University of Basel"
+      ],
+      "url": [
+        {
+          "name": "www.unibas.c",
+          "type": "https://schema.org/URL",
+          "url": "www.unibas.ch"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0826-person-002",
+      "familyName": "Heeg",
+      "givenName": "Stefanie",
+      "jobTitle": [
+        "Scientific collaborator"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0826-organization-001"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Grant",
+      "id": "http://ns.dasch.swiss/repository#dsp-0826-grant-000",
+      "funder": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0826-organization-000"
+        }
+      ],
+      "name": "Digital Lives",
+      "number": "183259",
+      "url": [
+        {
+          "name": "snf.ch",
+          "type": "https://schema.org/URL",
+          "url": "http://p3.snf.ch/Project-183259"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0826-person-003",
+      "familyName": "Reitzner Elliot",
+      "givenName": "Frédéric",
+      "jobTitle": [
+        "Scientific collaborator"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0826-organization-001"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Project",
+      "id": "http://ns.dasch.swiss/repository#dsp-0826-project",
+      "alternateName": [
+        "Intertextuality in drama of the early modern period",
+        "WordWeb / IDEM"
+      ],
+      "contactPoint": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0826-person-001"
+        }
+      ],
+      "description": "WordWeb/IDEM offers an innovative digital database for representing intertextuality in the drama of Shakespeare’s time. This digital representation based on Sematic Web technologies displays a comprehensive corpus of mutual quotations within the texts of this time. WordWeb renews our vision of intertextuality through a new paradigm for representing what is conventionally called “quotation”. Instead of complete texts, WordWeb/IDEM stores only intertextually active passages, i.e., phrases which have been identified in more than one text. These items are not seen as deriving from a famous masterpiece. Instead, they represent much- quoted phrases which just happen to occur also in Hamlet, for example. The name “WordWeb” indicates this new focus: short verbal items (“Word”) are connected to each other by rich links that carry bibliographical information and other annotations (“Web”). As a new methodology, WordWeb can be applied to advance research and understanding of complex relationships in many cultural domains.",
+      "discipline": [
+        "10501 Schwerpunkt Germanistik und Anglistik"
+      ],
+      "endDate": "2020-11-04",
+      "funder": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0826-organization-000"
+        }
+      ],
+      "grant": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0826-grant-000"
+        }
+      ],
+      "keywords": [
+        "Intertextuality",
+        "Early Modern Period",
+        "Elizabethan",
+        "English Drama",
+        "Digital Humanities",
+        "Shakespeare"
+      ],
+      "name": "WordWeb / IDEM: A new way of representing Intertextuality in Drama of the Early\r Modern Period",
+      "shortcode": "0826",
+      "spatialCoverage": [
+        {
+          "place": {
+            "name": "Geonames",
+            "url": "https://www.geonames.org/countries/GB/united-kingdom.html"
+          }
+        }
+      ],
+      "startDate": "2018-11-01",
+      "temporalCoverage": [
+        {
+          "name": "ChronOntology",
+          "type": "https://schema.org/URL",
+          "url": "https://chronontology.dainst.org/period/YOyP9TLDuhrb"
+        },
+        {
+          "name": "ChronOntology",
+          "type": "https://schema.org/URL",
+          "url": "https://chronontology.dainst.org/period/9Cb5HX6bZ92K"
+        },
+        {
+          "name": "ChronOntology",
+          "type": "https://schema.org/URL",
+          "url": "http://chronontology.dainst.org/period/yY1zReDz86zF"
+        },
+        {
+          "name": "ChronOntology",
+          "type": "https://schema.org/URL",
+          "url": "https://chronontology.dainst.org/period/ESV68rKHRuZg"
+        },
+        {
+          "name": "ChronOntology",
+          "type": "https://schema.org/URL",
+          "url": "https://chronontology.dainst.org/period/Fuxla9Z889Zq"
+        }
+      ],
+      "url": [
+        {
+          "name": "ark.dasch.sw",
+          "type": "https://schema.org/URL",
+          "url": "ark.dasch.swiss/ark:/72163/1/0826"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Person",
+      "id": "http://ns.dasch.swiss/repository#dsp-0826-person-001",
+      "familyName": "Hohl Trillini",
+      "givenName": "Regula",
+      "jobTitle": [
+        "Scientific collaborator"
+      ],
+      "memberOf": [
+        {
+          "id": "http://ns.dasch.swiss/repository#dsp-0826-organization-001"
+        }
+      ]
+    },
+    {
+      "type": "http://ns.dasch.swiss/repository#Organization",
+      "id": "http://ns.dasch.swiss/repository#dsp-0826-organization-000",
+      "address": {
+        "type": "https://schema.org/PostalAddress",
+        "addressLocality": "Bern",
+        "postalCode": "3001",
+        "streetAddress": "Wildhainweg 3, Postfach"
+      },
+      "email": "desk@snf.ch\rdesk@snf.ch",
+      "name": [
+        "Schweizerischer Nationalfonds (SNF)"
+      ],
+      "url": [
+        {
+          "name": "www.snf.ch",
+          "type": "https://schema.org/URL",
+          "url": "www.snf.ch"
+        }
+      ]
+    }
+  ]
+}

--- a/services/metadata/backend/fake-backend/fake-backend.go
+++ b/services/metadata/backend/fake-backend/fake-backend.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"path/filepath"
+	"regexp"
+	"strconv"
+
+	"github.com/gorilla/mux"
+)
+
+// Representation of a project
+type Project struct {
+	ID          string      `json:"id"`
+	Name        string      `json:"name"`
+	Description string      `json:"description"`
+	Metadata    interface{} `json:"metadata"`
+}
+
+// All projects that are being served
+var projects []Project
+
+// Full text search of a project.
+// Returns a slice of Projects where each project matches the search query.
+// Note: The query is a regex pattern and is matched against the JSON representation of the project.
+func searchProjects(query string) []Project {
+	var res []Project
+	for _, project := range projects {
+		content, _ := json.Marshal(project.Metadata)
+		match, _ := regexp.Match(query, content)
+		if match {
+			res = append(res, project)
+		}
+	}
+	return res
+}
+
+// Searches for a element with type == "http://ns.dasch.swiss/repository#Project"
+// in a json-shaped []interface{}
+func findProjectNode(list []interface{}) map[string]interface{} {
+	for _, item := range list {
+		innerMap, ok := item.(map[string]interface{})
+		if ok {
+			tp := innerMap["type"]
+			if tp == "http://ns.dasch.swiss/repository#Project" {
+				return innerMap
+			}
+		} else {
+			log.Fatal("Failed to parse node")
+		}
+	}
+	return nil
+}
+
+// Loads a project from a JSON file.
+// Expects this file to be located in ./data/*.json
+func loadProject(path string) Project {
+	// read json
+	byteValue, err := ioutil.ReadFile(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// unmarshal json
+	jsonMap := make(map[string]interface{})
+	err2 := json.Unmarshal(byteValue, &jsonMap)
+	if err2 != nil {
+		log.Fatal(err)
+	}
+
+	// grab actual metadata from JSON
+	projMetadata, ok := jsonMap["projectsMetadata"].([]interface{})
+	if ok {
+		projectMap := findProjectNode(projMetadata)
+		id := projectMap["shortcode"].(string)
+		name := projectMap["name"].(string)
+		description := projectMap["description"].(string)
+		return Project{
+			ID:          id,
+			Name:        name,
+			Description: description,
+			Metadata:    projMetadata,
+		}
+	} else {
+		log.Fatal("Could not find project in JSON")
+		return Project{}
+	}
+}
+
+// Load Project Data
+func loadProjectData() []Project {
+	var res []Project
+
+	paths, _ := filepath.Glob("./data/*.json")
+
+	for _, path := range paths {
+		res = append(res, loadProject(path))
+	}
+
+	return res
+}
+
+// Get projects
+func getProjects(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	// TODO: do we need links to previous and next and first an last?
+
+	// Request parameters
+	query := r.URL.Query().Get("q")
+	// TODO: does page start at 0 or 1?
+	page, _ := strconv.Atoi(r.URL.Query().Get("_page"))
+	limit, _ := strconv.Atoi(r.URL.Query().Get("_limit"))
+
+	matches := make([]Project, len(projects))
+
+	if query == "" {
+		// no search query all projects are matches
+		copy(matches, projects)
+	} else {
+		// reduce projects by search
+		matches = searchProjects(query)
+	}
+	// paginate
+	if len(matches) > 1 && len(matches) > limit && page > 0 && limit > 0 {
+		max := len(matches) - 1
+		start := (page - 1) * limit
+		if start > max {
+			start = max
+		}
+		end := page * limit
+		if end > max {
+			end = max
+		}
+		matches = matches[start:end]
+	}
+	// returns whatever remains
+	json.NewEncoder(w).Encode(matches)
+}
+
+// Get a single project
+func getProject(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	params := mux.Vars(r)
+	for _, item := range projects {
+		for item.ID == params["id"] {
+			json.NewEncoder(w).Encode(item)
+			return
+		}
+	}
+	json.NewEncoder(w).Encode(&Project{})
+}
+
+func main() {
+	a := []int{1}
+	log.Println(a[0:0])
+	// Init Router
+	router := mux.NewRouter()
+
+	// Set up routes
+	router.HandleFunc("/projects", getProjects).Methods("GET")
+	router.HandleFunc("/projects/{id}", getProject).Methods("GET")
+
+	// Load Data
+	projects = loadProjectData()
+
+	// Run server
+	log.Fatal(http.ListenAndServe("localhost:3001", router))
+}

--- a/services/metadata/backend/fake-backend/fake-backend.go
+++ b/services/metadata/backend/fake-backend/fake-backend.go
@@ -127,6 +127,7 @@ func getProjects(w http.ResponseWriter, r *http.Request) {
 		// reduce projects by search
 		matches = searchProjects(query)
 	}
+	w.Header().Set("X-Total-Count", strconv.Itoa(len(matches)))
 	// paginate
 	if len(matches) > 1 && len(matches) > limit && page > 0 && limit > 0 {
 		max := len(matches) - 1
@@ -169,7 +170,8 @@ func main() {
 	router.HandleFunc("/projects/{id}", getProject).Methods("GET")
 
 	// CORS header
-	ch := handlers.CORS(handlers.AllowedOrigins([]string{"http://localhost:5000"}))
+	ch := handlers.CORS(handlers.AllowedOrigins([]string{"*"}))
+	// ch := handlers.CORS(handlers.AllowedOrigins([]string{"http://localhost:5000"}))
 
 	// Load Data
 	projects = loadProjectData()


### PR DESCRIPTION
resolves DSP-1579

Not sure if this is actually better than `json-server` with `db.json`...  
This is a simple metadata server implemented in go, that emulates the functionality we used from `json-server`, provides the same API, but rather than one  `db.json`, it gets the data from one JSON file per project.
